### PR TITLE
原著のerrataについて言及

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -21,6 +21,9 @@ https://github.com/oreilly-japan/concurrency-in-go-support/wiki/errata
 
 本ページに掲載されていない誤植など間違いを見つけた方は、 `japan@oreilly.co.jp <mailto:japan@oreilly.co.jp>`_ までメールでお知らせいただくか、本レポジトリのIssueまでご連絡ください。
 
+なお原著のerrataについてはこちらにあります。
+
+https://www.oreilly.com/catalog/errata.csp?isbn=0636920046189
 
 本書に関するご質問
 ------------------------


### PR DESCRIPTION
原文で既知の誤りか判断しやすいように、原著のerrataの情報も記載